### PR TITLE
Improve memory_fs docs with descriptions

### DIFF
--- a/docs/memory_fs/Memory_FS.md
+++ b/docs/memory_fs/Memory_FS.md
@@ -1,0 +1,24 @@
+# Memory_FS.py
+
+
+## Description
+The main entry point to the in-memory file system. The `Memory_FS` class wires together all action classes such as load, save and delete.
+## Classes
+### Memory_FS
+Methods:
+- `data`
+- `delete`
+- `edit`
+- `load`
+- `save`
+
+```mermaid
+classDiagram
+    class Memory_FS {
+        data()
+        delete()
+        edit()
+        load()
+        save()
+    }
+```

--- a/docs/memory_fs/README.md
+++ b/docs/memory_fs/README.md
@@ -1,0 +1,20 @@
+# memory_fs
+
+
+## Description
+Documentation for the `memory_fs` package mirrored from source. Each subfolder documents a portion of the codebase.
+## Files
+- [Memory_FS.md](Memory_FS.md)
+- [__init__.md](__init__.md)
+- [version.md](version.md)
+
+## Subfolders
+- [actions](actions/README.md)
+- [core](core/README.md)
+- [file](file/README.md)
+- [file_types](file_types/README.md)
+- [path_handlers](path_handlers/README.md)
+- [project](project/README.md)
+- [schemas](schemas/README.md)
+- [storage](storage/README.md)
+- [utils](utils/README.md)

--- a/docs/memory_fs/__init__.md
+++ b/docs/memory_fs/__init__.md
@@ -1,0 +1,3 @@
+# __init__.py
+## Description
+Notes on the package initializer. It exposes shortcuts and sets up module level metadata.

--- a/docs/memory_fs/actions/Memory_FS__Data.md
+++ b/docs/memory_fs/actions/Memory_FS__Data.md
@@ -1,0 +1,30 @@
+# actions/Memory_FS__Data.py
+
+
+## Description
+Implements `Memory_FS__Data` which provides low level operations for reading file metadata and raw content from storage.
+## Classes
+### Memory_FS__Data
+Methods:
+- `paths`
+- `exists`
+- `exists_content`
+- `get_file_info`
+- `list_files`
+- `load`
+- `load_content`
+- `stats`
+
+```mermaid
+classDiagram
+    class Memory_FS__Data {
+        paths()
+        exists()
+        exists_content()
+        get_file_info()
+        list_files()
+        load()
+        load_content()
+        stats()
+    }
+```

--- a/docs/memory_fs/actions/Memory_FS__Delete.md
+++ b/docs/memory_fs/actions/Memory_FS__Delete.md
@@ -1,0 +1,22 @@
+# actions/Memory_FS__Delete.py
+
+
+## Description
+Defines `Memory_FS__Delete` used to remove files and their stored content. It leverages the edit and load actions to perform cleanup.
+## Classes
+### Memory_FS__Delete
+Methods:
+- `memory_fs__edit`
+- `memory_fs__load`
+- `memory__fs_storage`
+- `delete`
+
+```mermaid
+classDiagram
+    class Memory_FS__Delete {
+        memory_fs__edit()
+        memory_fs__load()
+        memory__fs_storage()
+        delete()
+    }
+```

--- a/docs/memory_fs/actions/Memory_FS__Deserialize.md
+++ b/docs/memory_fs/actions/Memory_FS__Deserialize.md
@@ -1,0 +1,16 @@
+# actions/Memory_FS__Deserialize.py
+
+
+## Description
+Contains `Memory_FS__Deserialize`, responsible for converting stored bytes into Python data according to the file's serialization format.
+## Classes
+### Memory_FS__Deserialize
+Methods:
+- `_deserialize_data`
+
+```mermaid
+classDiagram
+    class Memory_FS__Deserialize {
+        _deserialize_data()
+    }
+```

--- a/docs/memory_fs/actions/Memory_FS__Edit.md
+++ b/docs/memory_fs/actions/Memory_FS__Edit.md
@@ -1,0 +1,26 @@
+# actions/Memory_FS__Edit.py
+
+
+## Description
+Implements editing helpers that save or delete files from the underlying storage.
+## Classes
+### Memory_FS__Edit
+Methods:
+- `memory_fs__paths`
+- `clear`
+- `delete`
+- `delete_content`
+- `save`
+- `save_content`
+
+```mermaid
+classDiagram
+    class Memory_FS__Edit {
+        memory_fs__paths()
+        clear()
+        delete()
+        delete_content()
+        save()
+        save_content()
+    }
+```

--- a/docs/memory_fs/actions/Memory_FS__Load.md
+++ b/docs/memory_fs/actions/Memory_FS__Load.md
@@ -1,0 +1,26 @@
+# actions/Memory_FS__Load.py
+
+
+## Description
+Provides methods for locating and loading files from the configured paths. Includes helpers to fetch raw content or deserialized objects.
+## Classes
+### Memory_FS__Load
+Methods:
+- `memory_fs__data`
+- `memory_fs__deserialize`
+- `memory_fs__paths`
+- `load`
+- `load_content`
+- `load_data`
+
+```mermaid
+classDiagram
+    class Memory_FS__Load {
+        memory_fs__data()
+        memory_fs__deserialize()
+        memory_fs__paths()
+        load()
+        load_content()
+        load_data()
+    }
+```

--- a/docs/memory_fs/actions/Memory_FS__Paths.md
+++ b/docs/memory_fs/actions/Memory_FS__Paths.md
@@ -1,0 +1,18 @@
+# actions/Memory_FS__Paths.py
+
+
+## Description
+Utility for resolving the full list of paths for a file configuration. Handles metadata and content path generation.
+## Classes
+### Memory_FS__Paths
+Methods:
+- `paths`
+- `paths__content`
+
+```mermaid
+classDiagram
+    class Memory_FS__Paths {
+        paths()
+        paths__content()
+    }
+```

--- a/docs/memory_fs/actions/Memory_FS__Save.md
+++ b/docs/memory_fs/actions/Memory_FS__Save.md
@@ -1,0 +1,22 @@
+# actions/Memory_FS__Save.py
+
+
+## Description
+High level save routine that serializes data and writes both metadata and content to all configured locations.
+## Classes
+### Memory_FS__Save
+Methods:
+- `memory_fs__edit`
+- `memory__fs_paths`
+- `memory_fs__serialize`
+- `save`
+
+```mermaid
+classDiagram
+    class Memory_FS__Save {
+        memory_fs__edit()
+        memory__fs_paths()
+        memory_fs__serialize()
+        save()
+    }
+```

--- a/docs/memory_fs/actions/Memory_FS__Serialize.md
+++ b/docs/memory_fs/actions/Memory_FS__Serialize.md
@@ -1,0 +1,16 @@
+# actions/Memory_FS__Serialize.py
+
+
+## Description
+Serializes Python data into bytes based on the requested format such as JSON or base64.
+## Classes
+### Memory_FS__Serialize
+Methods:
+- `_serialize_data`
+
+```mermaid
+classDiagram
+    class Memory_FS__Serialize {
+        _serialize_data()
+    }
+```

--- a/docs/memory_fs/actions/README.md
+++ b/docs/memory_fs/actions/README.md
@@ -1,0 +1,15 @@
+# actions
+
+
+## Description
+Action modules implement the behaviour of the memory file system. Each file exposes a dedicated class.
+## Files
+- [Memory_FS__Data.md](Memory_FS__Data.md)
+- [Memory_FS__Delete.md](Memory_FS__Delete.md)
+- [Memory_FS__Deserialize.md](Memory_FS__Deserialize.md)
+- [Memory_FS__Edit.md](Memory_FS__Edit.md)
+- [Memory_FS__Load.md](Memory_FS__Load.md)
+- [Memory_FS__Paths.md](Memory_FS__Paths.md)
+- [Memory_FS__Save.md](Memory_FS__Save.md)
+- [Memory_FS__Serialize.md](Memory_FS__Serialize.md)
+- [__init__.md](__init__.md)

--- a/docs/memory_fs/actions/__init__.md
+++ b/docs/memory_fs/actions/__init__.md
@@ -1,0 +1,3 @@
+# actions/__init__.py
+## Description
+Package initializer for action modules.

--- a/docs/memory_fs/core/Memory_FS__File_System.md
+++ b/docs/memory_fs/core/Memory_FS__File_System.md
@@ -1,0 +1,13 @@
+# core/Memory_FS__File_System.py
+
+
+## Description
+Defines `Memory_FS__File_System`, the simple in-memory structure that stores files and associated content.
+## Classes
+### Memory_FS__File_System
+
+```mermaid
+classDiagram
+    class Memory_FS__File_System {
+    }
+```

--- a/docs/memory_fs/core/README.md
+++ b/docs/memory_fs/core/README.md
@@ -1,0 +1,8 @@
+# core
+
+
+## Description
+Core modules used internally by the memory file system implementation.
+## Files
+- [Memory_FS__File_System.md](Memory_FS__File_System.md)
+- [__init__.md](__init__.md)

--- a/docs/memory_fs/core/__init__.md
+++ b/docs/memory_fs/core/__init__.md
@@ -1,0 +1,3 @@
+# core/__init__.py
+## Description
+Package initializer for core components.

--- a/docs/memory_fs/file/Memory_FS__File.md
+++ b/docs/memory_fs/file/Memory_FS__File.md
@@ -1,0 +1,20 @@
+# file/Memory_FS__File.py
+
+
+## Description
+Thin wrapper around a file configuration and storage providing convenient access to data and edit helpers.
+## Classes
+### Memory_FS__File
+Methods:
+- `data`
+- `edit`
+- `exists`
+
+```mermaid
+classDiagram
+    class Memory_FS__File {
+        data()
+        edit()
+        exists()
+    }
+```

--- a/docs/memory_fs/file/Memory_FS__File__Storage.md
+++ b/docs/memory_fs/file/Memory_FS__File__Storage.md
@@ -1,0 +1,23 @@
+# file/Memory_FS__File__Storage.py
+
+
+## Description
+Defines storage configuration for a single file including how path handlers are combined.
+## Classes
+### Schema__Memory_FS__File__Storage__Config
+
+```mermaid
+classDiagram
+    class Schema__Memory_FS__File__Storage__Config {
+    }
+```
+### Memory_FS__File__Storage
+Methods:
+- `file__paths`
+
+```mermaid
+classDiagram
+    class Memory_FS__File__Storage {
+        file__paths()
+    }
+```

--- a/docs/memory_fs/file/README.md
+++ b/docs/memory_fs/file/README.md
@@ -1,0 +1,12 @@
+# file
+
+
+## Description
+Classes representing a single logical file and supporting helpers.
+## Files
+- [Memory_FS__File.md](Memory_FS__File.md)
+- [Memory_FS__File__Storage.md](Memory_FS__File__Storage.md)
+- [__init__.md](__init__.md)
+
+## Subfolders
+- [actions](actions/README.md)

--- a/docs/memory_fs/file/__init__.md
+++ b/docs/memory_fs/file/__init__.md
@@ -1,0 +1,3 @@
+# file/__init__.py
+## Description
+File package initializer.

--- a/docs/memory_fs/file/actions/Memory_FS__File__Data.md
+++ b/docs/memory_fs/file/actions/Memory_FS__File__Data.md
@@ -1,0 +1,18 @@
+# file/actions/Memory_FS__File__Data.py
+
+
+## Description
+Provides data centric helpers on a specific file instance such as checking for existence.
+## Classes
+### Memory_FS__File__Data
+Methods:
+- `memory_fs__data`
+- `exists`
+
+```mermaid
+classDiagram
+    class Memory_FS__File__Data {
+        memory_fs__data()
+        exists()
+    }
+```

--- a/docs/memory_fs/file/actions/Memory_FS__File__Edit.md
+++ b/docs/memory_fs/file/actions/Memory_FS__File__Edit.md
@@ -1,0 +1,24 @@
+# file/actions/Memory_FS__File__Edit.py
+
+
+## Description
+Editing helpers to manipulate an individual file's content.
+## Classes
+### Memory_FS__File__Edit
+Methods:
+- `storage_data`
+- `storage_edit`
+- `storage_paths`
+- `load__content`
+- `save__content`
+
+```mermaid
+classDiagram
+    class Memory_FS__File__Edit {
+        storage_data()
+        storage_edit()
+        storage_paths()
+        load__content()
+        save__content()
+    }
+```

--- a/docs/memory_fs/file/actions/README.md
+++ b/docs/memory_fs/file/actions/README.md
@@ -1,0 +1,9 @@
+# file/actions
+
+
+## Description
+Actions that operate within the scope of a specific file.
+## Files
+- [Memory_FS__File__Data.md](Memory_FS__File__Data.md)
+- [Memory_FS__File__Edit.md](Memory_FS__File__Edit.md)
+- [__init__.md](__init__.md)

--- a/docs/memory_fs/file/actions/__init__.md
+++ b/docs/memory_fs/file/actions/__init__.md
@@ -1,0 +1,3 @@
+# file/actions/__init__.py
+## Description
+Initializer for file action subpackage.

--- a/docs/memory_fs/file_types/Memory_FS__File__Type__Data.md
+++ b/docs/memory_fs/file_types/Memory_FS__File__Type__Data.md
@@ -1,0 +1,13 @@
+# file_types/Memory_FS__File__Type__Data.py
+
+
+## Description
+Base file type used mainly for testing and raw bytes.
+## Classes
+### Memory_FS__File__Type__Data
+
+```mermaid
+classDiagram
+    class Memory_FS__File__Type__Data {
+    }
+```

--- a/docs/memory_fs/file_types/Memory_FS__File__Type__Html.md
+++ b/docs/memory_fs/file_types/Memory_FS__File__Type__Html.md
@@ -1,0 +1,13 @@
+# file_types/Memory_FS__File__Type__Html.py
+
+
+## Description
+File type describing HTML files.
+## Classes
+### Memory_FS__File__Type__Html
+
+```mermaid
+classDiagram
+    class Memory_FS__File__Type__Html {
+    }
+```

--- a/docs/memory_fs/file_types/Memory_FS__File__Type__Jpeg.md
+++ b/docs/memory_fs/file_types/Memory_FS__File__Type__Jpeg.md
@@ -1,0 +1,13 @@
+# file_types/Memory_FS__File__Type__Jpeg.py
+
+
+## Description
+File type describing JPEG images.
+## Classes
+### Memory_FS__File__Type__Jpeg
+
+```mermaid
+classDiagram
+    class Memory_FS__File__Type__Jpeg {
+    }
+```

--- a/docs/memory_fs/file_types/Memory_FS__File__Type__Json.md
+++ b/docs/memory_fs/file_types/Memory_FS__File__Type__Json.md
@@ -1,0 +1,13 @@
+# file_types/Memory_FS__File__Type__Json.py
+
+
+## Description
+File type describing JSON data.
+## Classes
+### Memory_FS__File__Type__Json
+
+```mermaid
+classDiagram
+    class Memory_FS__File__Type__Json {
+    }
+```

--- a/docs/memory_fs/file_types/Memory_FS__File__Type__Markdown.md
+++ b/docs/memory_fs/file_types/Memory_FS__File__Type__Markdown.md
@@ -1,0 +1,13 @@
+# file_types/Memory_FS__File__Type__Markdown.py
+
+
+## Description
+File type describing Markdown documents.
+## Classes
+### Memory_FS__File__Type__Markdown
+
+```mermaid
+classDiagram
+    class Memory_FS__File__Type__Markdown {
+    }
+```

--- a/docs/memory_fs/file_types/Memory_FS__File__Type__Png.md
+++ b/docs/memory_fs/file_types/Memory_FS__File__Type__Png.md
@@ -1,0 +1,13 @@
+# file_types/Memory_FS__File__Type__Png.py
+
+
+## Description
+File type describing PNG images.
+## Classes
+### Memory_FS__File__Type__Png
+
+```mermaid
+classDiagram
+    class Memory_FS__File__Type__Png {
+    }
+```

--- a/docs/memory_fs/file_types/Memory_FS__File__Type__Text.md
+++ b/docs/memory_fs/file_types/Memory_FS__File__Type__Text.md
@@ -1,0 +1,13 @@
+# file_types/Memory_FS__File__Type__Text.py
+
+
+## Description
+File type describing plain text.
+## Classes
+### Memory_FS__File__Type__Text
+
+```mermaid
+classDiagram
+    class Memory_FS__File__Type__Text {
+    }
+```

--- a/docs/memory_fs/file_types/README.md
+++ b/docs/memory_fs/file_types/README.md
@@ -1,0 +1,14 @@
+# file_types
+
+
+## Description
+Collection of built-in file type definitions.
+## Files
+- [Memory_FS__File__Type__Data.md](Memory_FS__File__Type__Data.md)
+- [Memory_FS__File__Type__Html.md](Memory_FS__File__Type__Html.md)
+- [Memory_FS__File__Type__Jpeg.md](Memory_FS__File__Type__Jpeg.md)
+- [Memory_FS__File__Type__Json.md](Memory_FS__File__Type__Json.md)
+- [Memory_FS__File__Type__Markdown.md](Memory_FS__File__Type__Markdown.md)
+- [Memory_FS__File__Type__Png.md](Memory_FS__File__Type__Png.md)
+- [Memory_FS__File__Type__Text.md](Memory_FS__File__Type__Text.md)
+- [__init__.md](__init__.md)

--- a/docs/memory_fs/file_types/__init__.md
+++ b/docs/memory_fs/file_types/__init__.md
@@ -1,0 +1,3 @@
+# file_types/__init__.py
+## Description
+File types package initializer.

--- a/docs/memory_fs/path_handlers/Path__Handler.md
+++ b/docs/memory_fs/path_handlers/Path__Handler.md
@@ -1,0 +1,16 @@
+# path_handlers/Path__Handler.py
+
+
+## Description
+Abstract base class for all path handlers. Subclasses generate a destination path for a file.
+## Classes
+### Path__Handler
+Methods:
+- `generate_path`
+
+```mermaid
+classDiagram
+    class Path__Handler {
+        generate_path()
+    }
+```

--- a/docs/memory_fs/path_handlers/Path__Handler__Custom.md
+++ b/docs/memory_fs/path_handlers/Path__Handler__Custom.md
@@ -1,0 +1,16 @@
+# path_handlers/Path__Handler__Custom.py
+
+
+## Description
+Returns a user supplied path regardless of file id or extension.
+## Classes
+### Path__Handler__Custom
+Methods:
+- `generate_path`
+
+```mermaid
+classDiagram
+    class Path__Handler__Custom {
+        generate_path()
+    }
+```

--- a/docs/memory_fs/path_handlers/Path__Handler__Latest.md
+++ b/docs/memory_fs/path_handlers/Path__Handler__Latest.md
@@ -1,0 +1,16 @@
+# path_handlers/Path__Handler__Latest.py
+
+
+## Description
+Places files in a `latest` directory keeping only the most recent version.
+## Classes
+### Path__Handler__Latest
+Methods:
+- `generate_path`
+
+```mermaid
+classDiagram
+    class Path__Handler__Latest {
+        generate_path()
+    }
+```

--- a/docs/memory_fs/path_handlers/Path__Handler__Temporal.md
+++ b/docs/memory_fs/path_handlers/Path__Handler__Temporal.md
@@ -1,0 +1,18 @@
+# path_handlers/Path__Handler__Temporal.py
+
+
+## Description
+Builds a path that embeds a timestamp creating a simple history of versions.
+## Classes
+### Path__Handler__Temporal
+Methods:
+- `generate_path`
+- `path_now`
+
+```mermaid
+classDiagram
+    class Path__Handler__Temporal {
+        generate_path()
+        path_now()
+    }
+```

--- a/docs/memory_fs/path_handlers/Path__Handler__Versioned.md
+++ b/docs/memory_fs/path_handlers/Path__Handler__Versioned.md
@@ -1,0 +1,16 @@
+# path_handlers/Path__Handler__Versioned.py
+
+
+## Description
+Adds an incremental integer to paths so multiple versions can be saved.
+## Classes
+### Path__Handler__Versioned
+Methods:
+- `generate_path`
+
+```mermaid
+classDiagram
+    class Path__Handler__Versioned {
+        generate_path()
+    }
+```

--- a/docs/memory_fs/path_handlers/README.md
+++ b/docs/memory_fs/path_handlers/README.md
@@ -1,0 +1,12 @@
+# path_handlers
+
+
+## Description
+Handlers that build file paths dynamically based on different strategies.
+## Files
+- [Path__Handler.md](Path__Handler.md)
+- [Path__Handler__Custom.md](Path__Handler__Custom.md)
+- [Path__Handler__Latest.md](Path__Handler__Latest.md)
+- [Path__Handler__Temporal.md](Path__Handler__Temporal.md)
+- [Path__Handler__Versioned.md](Path__Handler__Versioned.md)
+- [__init__.md](__init__.md)

--- a/docs/memory_fs/path_handlers/__init__.md
+++ b/docs/memory_fs/path_handlers/__init__.md
@@ -1,0 +1,16 @@
+# path_handlers/__init__.py
+
+
+## Description
+Package initializer for path handlers.
+## Classes
+### Path__Handler__Latest
+Methods:
+- `generate_path`
+
+```mermaid
+classDiagram
+    class Path__Handler__Latest {
+        generate_path()
+    }
+```

--- a/docs/memory_fs/project/Memory_FS__Project.md
+++ b/docs/memory_fs/project/Memory_FS__Project.md
@@ -1,0 +1,20 @@
+# project/Memory_FS__Project.py
+
+
+## Description
+High level helper for working with sets of files organised into projects.
+## Classes
+### Memory_FS__Project
+Methods:
+- `file`
+- `memory_fs`
+- `path_strategy`
+
+```mermaid
+classDiagram
+    class Memory_FS__Project {
+        file()
+        memory_fs()
+        path_strategy()
+    }
+```

--- a/docs/memory_fs/project/README.md
+++ b/docs/memory_fs/project/README.md
@@ -1,0 +1,9 @@
+# project
+
+
+## Description
+Project related utilities.
+## Files
+- [Memory_FS__Project.md](Memory_FS__Project.md)
+- [Schema__Memory_FS__Project__Config.md](Schema__Memory_FS__Project__Config.md)
+- [__init__.md](__init__.md)

--- a/docs/memory_fs/project/Schema__Memory_FS__Project__Config.md
+++ b/docs/memory_fs/project/Schema__Memory_FS__Project__Config.md
@@ -1,0 +1,20 @@
+# project/Schema__Memory_FS__Project__Config.py
+
+
+## Description
+Schema defining how a project is configured including its available path strategies and storage provider.
+## Classes
+### Schema__Memory_FS__Project__Path_Strategy
+
+```mermaid
+classDiagram
+    class Schema__Memory_FS__Project__Path_Strategy {
+    }
+```
+### Schema__Memory_FS__Project__Config
+
+```mermaid
+classDiagram
+    class Schema__Memory_FS__Project__Config {
+    }
+```

--- a/docs/memory_fs/project/__init__.md
+++ b/docs/memory_fs/project/__init__.md
@@ -1,0 +1,3 @@
+# project/__init__.py
+## Description
+Project package initializer.

--- a/docs/memory_fs/schemas/Enum__Memory_FS__File__Content_Type.md
+++ b/docs/memory_fs/schemas/Enum__Memory_FS__File__Content_Type.md
@@ -1,0 +1,13 @@
+# schemas/Enum__Memory_FS__File__Content_Type.py
+
+
+## Description
+Enumeration of allowed content types such as JSON or PNG.
+## Classes
+### Enum__Memory_FS__File__Content_Type
+
+```mermaid
+classDiagram
+    class Enum__Memory_FS__File__Content_Type {
+    }
+```

--- a/docs/memory_fs/schemas/Enum__Memory_FS__File__Encoding.md
+++ b/docs/memory_fs/schemas/Enum__Memory_FS__File__Encoding.md
@@ -1,0 +1,13 @@
+# schemas/Enum__Memory_FS__File__Encoding.py
+
+
+## Description
+Enumeration of encoding choices used when reading or writing text.
+## Classes
+### Enum__Memory_FS__File__Encoding
+
+```mermaid
+classDiagram
+    class Enum__Memory_FS__File__Encoding {
+    }
+```

--- a/docs/memory_fs/schemas/Enum__Memory_FS__Serialization.md
+++ b/docs/memory_fs/schemas/Enum__Memory_FS__Serialization.md
@@ -1,0 +1,13 @@
+# schemas/Enum__Memory_FS__Serialization.py
+
+
+## Description
+Enumeration controlling how complex data is serialized to bytes.
+## Classes
+### Enum__Memory_FS__Serialization
+
+```mermaid
+classDiagram
+    class Enum__Memory_FS__Serialization {
+    }
+```

--- a/docs/memory_fs/schemas/README.md
+++ b/docs/memory_fs/schemas/README.md
@@ -1,0 +1,15 @@
+# schemas
+
+
+## Description
+Schemas and enums used throughout the memory file system.
+## Files
+- [Enum__Memory_FS__File__Content_Type.md](Enum__Memory_FS__File__Content_Type.md)
+- [Enum__Memory_FS__File__Encoding.md](Enum__Memory_FS__File__Encoding.md)
+- [Enum__Memory_FS__Serialization.md](Enum__Memory_FS__Serialization.md)
+- [Schema__Memory_FS__File.md](Schema__Memory_FS__File.md)
+- [Schema__Memory_FS__File__Config.md](Schema__Memory_FS__File__Config.md)
+- [Schema__Memory_FS__File__Metadata.md](Schema__Memory_FS__File__Metadata.md)
+- [Schema__Memory_FS__File__Type.md](Schema__Memory_FS__File__Type.md)
+- [Schema__Memory_FS__Path__Handler.md](Schema__Memory_FS__Path__Handler.md)
+- [__init__.md](__init__.md)

--- a/docs/memory_fs/schemas/Schema__Memory_FS__File.md
+++ b/docs/memory_fs/schemas/Schema__Memory_FS__File.md
@@ -1,0 +1,13 @@
+# schemas/Schema__Memory_FS__File.py
+
+
+## Description
+Schema bundling together a file's config and its metadata.
+## Classes
+### Schema__Memory_FS__File
+
+```mermaid
+classDiagram
+    class Schema__Memory_FS__File {
+    }
+```

--- a/docs/memory_fs/schemas/Schema__Memory_FS__File__Config.md
+++ b/docs/memory_fs/schemas/Schema__Memory_FS__File__Config.md
@@ -1,0 +1,13 @@
+# schemas/Schema__Memory_FS__File__Config.py
+
+
+## Description
+Schema describing identifiers, paths and file type for a file.
+## Classes
+### Schema__Memory_FS__File__Config
+
+```mermaid
+classDiagram
+    class Schema__Memory_FS__File__Config {
+    }
+```

--- a/docs/memory_fs/schemas/Schema__Memory_FS__File__Metadata.md
+++ b/docs/memory_fs/schemas/Schema__Memory_FS__File__Metadata.md
@@ -1,0 +1,13 @@
+# schemas/Schema__Memory_FS__File__Metadata.py
+
+
+## Description
+Schema capturing size, hash and timestamp information about stored content.
+## Classes
+### Schema__Memory_FS__File__Metadata
+
+```mermaid
+classDiagram
+    class Schema__Memory_FS__File__Metadata {
+    }
+```

--- a/docs/memory_fs/schemas/Schema__Memory_FS__File__Type.md
+++ b/docs/memory_fs/schemas/Schema__Memory_FS__File__Type.md
@@ -1,0 +1,13 @@
+# schemas/Schema__Memory_FS__File__Type.py
+
+
+## Description
+Base schema for defining custom file types.
+## Classes
+### Schema__Memory_FS__File__Type
+
+```mermaid
+classDiagram
+    class Schema__Memory_FS__File__Type {
+    }
+```

--- a/docs/memory_fs/schemas/Schema__Memory_FS__Path__Handler.md
+++ b/docs/memory_fs/schemas/Schema__Memory_FS__Path__Handler.md
@@ -1,0 +1,13 @@
+# schemas/Schema__Memory_FS__Path__Handler.py
+
+
+## Description
+Schema used to configure path handler classes.
+## Classes
+### Schema__Memory_FS__Path__Handler
+
+```mermaid
+classDiagram
+    class Schema__Memory_FS__Path__Handler {
+    }
+```

--- a/docs/memory_fs/schemas/__init__.md
+++ b/docs/memory_fs/schemas/__init__.md
@@ -1,0 +1,3 @@
+# schemas/__init__.py
+## Description
+Schemas package initializer.

--- a/docs/memory_fs/storage/Memory_FS__Storage.md
+++ b/docs/memory_fs/storage/Memory_FS__Storage.md
@@ -1,0 +1,26 @@
+# storage/Memory_FS__Storage.py
+
+
+## Description
+Implements the in-memory storage backend used by the rest of the system.
+## Classes
+### Memory_FS__Storage
+Methods:
+- `content_data`
+- `file`
+- `file__content`
+- `files`
+- `files__contents`
+- `files__names`
+
+```mermaid
+classDiagram
+    class Memory_FS__Storage {
+        content_data()
+        file()
+        file__content()
+        files()
+        files__contents()
+        files__names()
+    }
+```

--- a/docs/memory_fs/storage/README.md
+++ b/docs/memory_fs/storage/README.md
@@ -1,0 +1,8 @@
+# storage
+
+
+## Description
+Storage subsystem details.
+## Files
+- [Memory_FS__Storage.md](Memory_FS__Storage.md)
+- [__init__.md](__init__.md)

--- a/docs/memory_fs/storage/__init__.md
+++ b/docs/memory_fs/storage/__init__.md
@@ -1,0 +1,3 @@
+# storage/__init__.py
+## Description
+Storage package initializer.

--- a/docs/memory_fs/utils/README.md
+++ b/docs/memory_fs/utils/README.md
@@ -1,0 +1,8 @@
+# utils
+
+
+## Description
+Utility helpers used by the library.
+## Files
+- [Version.md](Version.md)
+- [__init__.md](__init__.md)

--- a/docs/memory_fs/utils/Version.md
+++ b/docs/memory_fs/utils/Version.md
@@ -1,0 +1,20 @@
+# utils/Version.py
+
+
+## Description
+Helper to read the current version from the package directory.
+## Classes
+### Version
+Methods:
+- `path_code_root`
+- `path_version_file`
+- `value`
+
+```mermaid
+classDiagram
+    class Version {
+        path_code_root()
+        path_version_file()
+        value()
+    }
+```

--- a/docs/memory_fs/utils/__init__.md
+++ b/docs/memory_fs/utils/__init__.md
@@ -1,0 +1,3 @@
+# utils/__init__.py
+## Description
+Utils package initializer.

--- a/docs/memory_fs/version.md
+++ b/docs/memory_fs/version.md
@@ -1,0 +1,6 @@
+# version
+
+
+## Description
+Holds the version string for releases.
+Contains the current version string of the library.


### PR DESCRIPTION
## Summary
- insert a description section into every doc under `docs/memory_fs`
- explain purpose of modules like `Memory_FS__Load`
- document folder READMEs with introductory text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for osbot_utils)*

------
https://chatgpt.com/codex/tasks/task_e_683db4ed6d1c8326a5186a8c52df1ec1