### PR TITLE
Improve memory_fs docs

### DIFF
--- a/docs/memory_fs/Memory_FS.md
+++ b/docs/memory_fs/Memory_FS.md
@@ -13,12 +13,11 @@ Methods:
 - `save`
 
 ```mermaid
-classDiagram
-    class Memory_FS {
-        data()
-        delete()
-        edit()
-        load()
-        save()
-    }
+flowchart TD
+    A[Memory_FS instance]
+    A --> B[data()]
+    A --> C[delete()]
+    A --> D[edit()]
+    A --> E[load()]
+    A --> F[save()]
 ```

--- a/docs/memory_fs/README.md
+++ b/docs/memory_fs/README.md
@@ -2,7 +2,15 @@
 
 
 ## Description
-Documentation for the `memory_fs` package mirrored from source. Each subfolder documents a portion of the codebase.
+Documentation for the `memory_fs` package mirrored from source. Each subfolder
+captures notes and Mermaid visualisations for the corresponding part of the
+codebase.  The goal is for these files to stay close to the latest source so
+that newcomers can understand the responsibilities of every module.
+
+## Updating documentation
+There is no automated generation step.  When the code changes, update the
+markdown file under the matching path.  After making changes run the test suite
+with `pytest -q` to ensure nothing broke.
 ## Files
 - [Memory_FS.md](Memory_FS.md)
 - [__init__.md](__init__.md)

--- a/docs/memory_fs/actions/Memory_FS__Data.md
+++ b/docs/memory_fs/actions/Memory_FS__Data.md
@@ -16,15 +16,11 @@ Methods:
 - `stats`
 
 ```mermaid
-classDiagram
-    class Memory_FS__Data {
-        paths()
-        exists()
-        exists_content()
-        get_file_info()
-        list_files()
-        load()
-        load_content()
-        stats()
-    }
+flowchart TD
+    A[exists(config)] --> B[paths(config)]
+    B --> C{found?}
+    C -- yes --> D[True]
+    C -- no --> E[False]
+    A2[list_files(prefix)] --> F[iterate storage files]
+    A3[load_content(path)] --> G[storage.file__content(path)]
 ```

--- a/docs/memory_fs/actions/Memory_FS__Delete.md
+++ b/docs/memory_fs/actions/Memory_FS__Delete.md
@@ -12,11 +12,10 @@ Methods:
 - `delete`
 
 ```mermaid
-classDiagram
-    class Memory_FS__Delete {
-        memory_fs__edit()
-        memory_fs__load()
-        memory__fs_storage()
-        delete()
-    }
+flowchart TD
+    A[delete(config)] --> B[edit.delete(config)]
+    A --> C[edit.delete_content(config)]
+    B --> D[result list]
+    C --> D
+    D --> E[return summary]
 ```

--- a/docs/memory_fs/actions/Memory_FS__Load.md
+++ b/docs/memory_fs/actions/Memory_FS__Load.md
@@ -14,13 +14,9 @@ Methods:
 - `load_data`
 
 ```mermaid
-classDiagram
-    class Memory_FS__Load {
-        memory_fs__data()
-        memory_fs__deserialize()
-        memory_fs__paths()
-        load()
-        load_content()
-        load_data()
-    }
+flowchart TD
+    A[load_data(config)] --> B[paths(config)]
+    B --> C[load_content(path)]
+    C --> D[_deserialize_data]
+    D --> E[return object]
 ```

--- a/docs/memory_fs/actions/Memory_FS__Save.md
+++ b/docs/memory_fs/actions/Memory_FS__Save.md
@@ -7,16 +7,16 @@ High level save routine that serializes data and writes both metadata and conten
 ### Memory_FS__Save
 Methods:
 - `memory_fs__edit`
-- `memory__fs_paths`
 - `memory_fs__serialize`
 - `save`
 
 ```mermaid
-classDiagram
-    class Memory_FS__Save {
-        memory_fs__edit()
-        memory__fs_paths()
-        memory_fs__serialize()
-        save()
-    }
+flowchart TD
+    A[save(data, config)] --> B[_serialize_data]
+    B --> C[build metadata]
+    C --> D[edit.save(file)]
+    C --> E[edit.save_content(bytes)]
+    D --> F[paths]
+    E --> F
+    F --> G[sorted list of paths]
 ```

--- a/docs/memory_fs/actions/README.md
+++ b/docs/memory_fs/actions/README.md
@@ -2,7 +2,8 @@
 
 
 ## Description
-Action modules implement the behaviour of the memory file system. Each file exposes a dedicated class.
+Action modules implement the behaviour of the memory file system. Each file exposes
+a dedicated class and the diagrams illustrate how data flows through the methods.
 ## Files
 - [Memory_FS__Data.md](Memory_FS__Data.md)
 - [Memory_FS__Delete.md](Memory_FS__Delete.md)

--- a/docs/memory_fs/path_handlers/Path__Handler__Custom.md
+++ b/docs/memory_fs/path_handlers/Path__Handler__Custom.md
@@ -9,8 +9,6 @@ Methods:
 - `generate_path`
 
 ```mermaid
-classDiagram
-    class Path__Handler__Custom {
-        generate_path()
-    }
+flowchart TD
+    A[generate_path()] --> B[return custom_path]
 ```

--- a/docs/memory_fs/path_handlers/Path__Handler__Latest.md
+++ b/docs/memory_fs/path_handlers/Path__Handler__Latest.md
@@ -9,8 +9,6 @@ Methods:
 - `generate_path`
 
 ```mermaid
-classDiagram
-    class Path__Handler__Latest {
-        generate_path()
-    }
+flowchart TD
+    A[generate_path()] --> B[return 'latest']
 ```

--- a/docs/memory_fs/path_handlers/Path__Handler__Temporal.md
+++ b/docs/memory_fs/path_handlers/Path__Handler__Temporal.md
@@ -10,9 +10,8 @@ Methods:
 - `path_now`
 
 ```mermaid
-classDiagram
-    class Path__Handler__Temporal {
-        generate_path()
-        path_now()
-    }
+flowchart TD
+    A[path_now()] --> B[format current time]
+    C[generate_path()] --> A
+    C --> D[append areas if provided]
 ```

--- a/docs/memory_fs/path_handlers/Path__Handler__Versioned.md
+++ b/docs/memory_fs/path_handlers/Path__Handler__Versioned.md
@@ -9,8 +9,6 @@ Methods:
 - `generate_path`
 
 ```mermaid
-classDiagram
-    class Path__Handler__Versioned {
-        generate_path()
-    }
+flowchart TD
+    A[generate_path(file_id,ext,version)] --> B[format "v{version}/{file_id}{ext}"]
 ```

--- a/docs/memory_fs/path_handlers/README.md
+++ b/docs/memory_fs/path_handlers/README.md
@@ -2,7 +2,8 @@
 
 
 ## Description
-Handlers that build file paths dynamically based on different strategies.
+Handlers that build file paths dynamically based on different strategies. The
+Mermaid flowcharts in each file show how the path strings are produced.
 ## Files
 - [Path__Handler.md](Path__Handler.md)
 - [Path__Handler__Custom.md](Path__Handler__Custom.md)

--- a/docs/memory_fs/storage/Memory_FS__Storage.md
+++ b/docs/memory_fs/storage/Memory_FS__Storage.md
@@ -14,13 +14,14 @@ Methods:
 - `files__names`
 
 ```mermaid
-classDiagram
-    class Memory_FS__Storage {
-        content_data()
-        file()
-        file__content()
-        files()
-        files__contents()
-        files__names()
-    }
+flowchart TD
+    A[Memory_FS__Storage]
+    A --> B[files dict]
+    A --> C[content_data dict]
+    subgraph Access
+        D[files()] --> B
+        E[file(path)] --> B
+        F[file__content(path)] --> C
+        G[files__names()] --> B
+    end
 ```


### PR DESCRIPTION
## Summary
- document update process in docs/memory_fs README
- switch Mermaid diagrams to logic flows
- fix method list for Memory_FS__Save and update diagram
- clarify module notes in actions and path handler READMEs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684175f7da1483269476ae6dbaa51bf3