### PR TITLE
Add doc indexes and bug links

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,11 @@ print(f"Data loaded from {file_name}.{file_config.file_type.file_extension}: {lo
 ```
 
 **Note:** The project currently uses `Memory_FS__File__System` for in-memory storage. The path handlers like `Path__Handler__Latest` are defined, but their specific `generate_path` logic might be simulated in some actions (as seen in `Memory_FS__Save`). The example above reflects a functional case based on the current codebase.
+
+## Documentation
+
+Additional project notes are available under the `docs` folder. Key pages include:
+
+- [Developer Documentation](docs/dev/README.md)
+  - [Known Bugs](docs/dev/bugs/README.md)
+  - [TODO Lists](docs/dev/todos/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation Overview
+
+This folder hosts all project documentation. Key sections include:
+
+- [Architecture](architecture/technical_architecture_debrief.md)
+- [Code Analysis](code-analysis/memory_fs/README.md)
+- [Developer Docs](dev/README.md)
+- [Security](security/threat_model.md)
+- [Technical Debriefs](tech_debriefs/README.md)

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -1,0 +1,7 @@
+# Developer Documentation
+
+This directory contains notes and guides relevant to development.
+
+- [Python code formatting guidelines](Python-code-formatting-guidelines.md)
+- [Bugs](bugs/README.md)
+- [TODOs](todos/README.md)

--- a/docs/dev/bugs/README.md
+++ b/docs/dev/bugs/README.md
@@ -4,5 +4,5 @@ This folder collects known bugs for the project.
 Each markdown file groups related issues so that they are easier to track.
 
 Files included here:
-- `runtime_bugs.md` – open bugs found in the core code base.
-- `test_bugs.md` – bug notes that live in the unit tests.
+- [`runtime_bugs.md`](runtime_bugs.md) – open bugs found in the core code base.
+- [`test_bugs.md`](test_bugs.md) – bug notes that live in the unit tests.

--- a/docs/dev/bugs/runtime_bugs.md
+++ b/docs/dev/bugs/runtime_bugs.md
@@ -5,14 +5,14 @@ This file lists open defects observed directly in the source code.
 ## File management
 
 ### Memory_FS__Delete.delete returns wrong type
-File: `memory_fs/actions/Memory_FS__Delete.py`
+File: [`memory_fs/actions/Memory_FS__Delete.py`](https://github.com/owasp-sbot/Memory-FS/blob/dev/memory_fs/actions/Memory_FS__Delete.py)
 The function advertises `Dict[Safe_Id, bool]` but concatenates two lists of paths, yielding a list instead.
 
 ### File name with null extension
-File: `memory_fs/file/actions/File_FS__Name.py`
+File: [`memory_fs/file/actions/File_FS__Name.py`](https://github.com/owasp-sbot/Memory-FS/blob/dev/memory_fs/file/actions/File_FS__Name.py)
 When `file_type.file_extension` is `None` the resulting path may include the string `"None"`. The implementation needs to skip adding the extension when not set.
 
 ## Metadata
 
 ### Content size not captured
-Tests show `content__size` remains `0` after saving. The metadata update in `Memory_FS__Edit.save` and related helpers is incomplete.
+Tests show `content__size` remains `0` after saving. The metadata update in [`Memory_FS__Edit.save`](https://github.com/owasp-sbot/Memory-FS/blob/dev/memory_fs/actions/Memory_FS__Edit.py) and related helpers is incomplete.

--- a/docs/dev/bugs/test_bugs.md
+++ b/docs/dev/bugs/test_bugs.md
@@ -3,8 +3,8 @@
 Some unit tests contain BUG comments that highlight inconsistencies.
 
 ## File data tests
-- `tests/unit/file/actions/test_Memory_FS__File__Data.py` shows an expected path mismatch.
-- `tests/unit/file/test_Memory_FS__File.py` includes assertions commented with "Should be true/false" indicating behaviour disagreements.
+- [`tests/unit/file/actions/test_Memory_FS__File__Data.py`](https://github.com/owasp-sbot/Memory-FS/blob/dev/tests/unit/file/actions/test_Memory_FS__File__Data.py) shows an expected path mismatch.
+- [`tests/unit/file/test_Memory_FS__File.py`](https://github.com/owasp-sbot/Memory-FS/blob/dev/tests/unit/file/test_Memory_FS__File.py) includes assertions commented with "Should be true/false" indicating behaviour disagreements.
 
 ## Memory file system tests
-- `tests/unit/memory/test_Memory_FS__Memory__File_System.py` contains several BUG notes around the `content__size` field remaining zero after saving.
+- [`tests/unit/memory/test_Memory_FS__Memory__File_System.py`](https://github.com/owasp-sbot/Memory-FS/blob/dev/tests/unit/memory/test_Memory_FS__Memory__File_System.py) contains several BUG notes around the `content__size` field remaining zero after saving.

--- a/docs/dev/todos/README.md
+++ b/docs/dev/todos/README.md
@@ -4,6 +4,6 @@ This directory records outstanding TODO items extracted from the code base.
 The notes are divided by area so future development can focus on one file.
 
 Files included here:
-- `core_todos.md` – tasks for the main API and data management classes.
-- `storage_providers.md` – items related to the storage backends and helpers.
-- `tests.md` – TODO notes inside the unit tests.
+- [`core_todos.md`](core_todos.md) – tasks for the main API and data management classes.
+- [`storage_providers.md`](storage_providers.md) – items related to the storage backends and helpers.
+- [`tests.md`](tests.md) – TODO notes inside the unit tests.

--- a/docs/dev/todos/tests.md
+++ b/docs/dev/todos/tests.md
@@ -2,7 +2,7 @@
 
 Several tests contain TODO notes for future improvements.
 
-- `tests/unit/actions/test_Memory_FS__Paths.py` documents expected behaviour for path generation and lists outstanding items.
-- `tests/unit/file/actions/test_Memory_FS__File__Create.py` uses `Storage_FS__Memory` by default and should revisit once the storage abstraction is finalised.
-- `tests/unit/memory/test_Memory_FS__Memory__File_System.py` still relies on early prototypes and will be refactored when the new `Memory_FS__*` classes stabilize.
-- `tests/unit/memory/test_Memory_FS__Memory__Storage.py` flags naming issues for the generated `.fs.json` files and includes a value check that needs verifying.
+- [`tests/unit/actions/test_Memory_FS__Paths.py`](https://github.com/owasp-sbot/Memory-FS/blob/dev/tests/unit/actions/test_Memory_FS__Paths.py) documents expected behaviour for path generation and lists outstanding items.
+- [`tests/unit/file/actions/test_Memory_FS__File__Create.py`](https://github.com/owasp-sbot/Memory-FS/blob/dev/tests/unit/file/actions/test_Memory_FS__File__Create.py) uses `Storage_FS__Memory` by default and should revisit once the storage abstraction is finalised.
+- [`tests/unit/memory/test_Memory_FS__Memory__File_System.py`](https://github.com/owasp-sbot/Memory-FS/blob/dev/tests/unit/memory/test_Memory_FS__Memory__File_System.py) still relies on early prototypes and will be refactored when the new `Memory_FS__*` classes stabilize.
+- [`tests/unit/memory/test_Memory_FS__Memory__Storage.py`](https://github.com/owasp-sbot/Memory-FS/blob/dev/tests/unit/memory/test_Memory_FS__Memory__Storage.py) flags naming issues for the generated `.fs.json` files and includes a value check that needs verifying.


### PR DESCRIPTION
## Summary
- hyperlink code paths inside runtime and test bug docs
- link referenced tests inside TODO notes
- add README indexes for docs and dev docs
- link docs from the main README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff1ce56048326a2a9c57e5b830f42